### PR TITLE
Refine LSP client compatibility helpers

### DIFF
--- a/lua/polish.lua
+++ b/lua/polish.lua
@@ -11,6 +11,28 @@ local function save_if_writable()
   vim.cmd("silent! update")
 end
 
+local function list_lsp_clients(opts)
+  if not vim.lsp then return {} end
+
+  if type(vim.lsp.get_clients) == "function" then
+    return vim.lsp.get_clients(opts)
+  end
+
+  if type(vim.lsp.buf_get_clients) == "function" then
+    if type(opts) == "table" and opts.bufnr then
+      return vim.lsp.buf_get_clients(opts.bufnr)
+    end
+    if type(opts) == "number" then return vim.lsp.buf_get_clients(opts) end
+    return vim.lsp.buf_get_clients()
+  end
+
+  if type(vim.lsp.get_active_clients) == "function" then
+    return vim.lsp.get_active_clients()
+  end
+
+  return {}
+end
+
 -- Auto-save when toggling between insert and normal modes
 local mode_switch_group = vim.api.nvim_create_augroup("UserAutoSaveModeSwitch", { clear = true })
 
@@ -54,7 +76,7 @@ vim.api.nvim_create_autocmd("InsertLeave", {
     if vim.api.nvim_buf_get_name(buf) == "" or not vim.bo[buf].modified then return end
 
     local has_gopls = false
-    for _, client in ipairs(vim.lsp.get_active_clients({ bufnr = buf })) do
+    for _, client in ipairs(list_lsp_clients({ bufnr = buf })) do
       if client.name == "gopls" then
         has_gopls = true
         break

--- a/lua/user/polish.lua
+++ b/lua/user/polish.lua
@@ -1,37 +1,109 @@
-if vim.lsp then
-  local has_new = type(vim.lsp.get_clients) == "function"
-  local has_old = type(vim.lsp.buf_get_clients) == "function"
-  -- Backfill the new API on older versions without keeping deprecated calls around
-  if not has_new and has_old then
-    vim.lsp.get_clients = function(opts)
-      if type(opts) == "table" and opts.bufnr ~= nil then
-        return vim.lsp.buf_get_clients(opts.bufnr)
-      end
-      if type(opts) == "number" then return vim.lsp.buf_get_clients(opts) end
-      return vim.lsp.buf_get_clients()
+local function list_lsp_clients(opts)
+  if not vim.lsp then return {} end
+
+  if type(vim.lsp.get_clients) == "function" then
+    return vim.lsp.get_clients(opts)
+  end
+
+  if type(vim.lsp.buf_get_clients) == "function" then
+    if type(opts) == "table" and opts.bufnr then
+      return vim.lsp.buf_get_clients(opts.bufnr)
+    end
+    if type(opts) == "number" then return vim.lsp.buf_get_clients(opts) end
+    return vim.lsp.buf_get_clients()
+  end
+
+  if type(vim.lsp.get_active_clients) == "function" then
+    return vim.lsp.get_active_clients()
+  end
+
+  return {}
+end
+
+local function get_client_by_id(id)
+  if not (vim.lsp and id) then return nil end
+  if type(vim.lsp.get_client_by_id) == "function" then
+    return vim.lsp.get_client_by_id(id)
+  end
+  local active_clients = list_lsp_clients()
+  if type(active_clients) == "table" then
+    for _, client in pairs(active_clients) do
+      if client.id == id then return client end
     end
   end
 end
 
--- >>> Inlay Hints: по умолчанию выкл + тоггл по клавише
-vim.api.nvim_create_autocmd("LspAttach", {
-  group = vim.api.nvim_create_augroup("UserInlayHints", { clear = true }),
-  callback = function(args)
-    local client = vim.lsp.get_client_by_id(args.data.client_id)
-    if client and client.supports_method("textDocument/inlayHint") then
-      vim.lsp.inlay_hint.enable(args.buf, false)
-    end
-  end,
-})
+local has_inlay_hint_api = vim.lsp and type(vim.lsp.inlay_hint) == "table"
+local has_inlay_hint_enable = has_inlay_hint_api and type(vim.lsp.inlay_hint.enable) == "function"
+local has_inlay_hint_is_enabled = has_inlay_hint_api and type(vim.lsp.inlay_hint.is_enabled) == "function"
+local has_legacy_inlay_hint = vim.lsp and vim.lsp.buf and type(vim.lsp.buf.inlay_hint) == "function"
 
--- Переключатель: <leader>uh (u = ui, h = hints)
-vim.keymap.set("n", "<leader>uh", function()
-  local buf = vim.api.nvim_get_current_buf()
-  local enabled = vim.lsp.inlay_hint.is_enabled(buf)
-  vim.lsp.inlay_hint.enable(buf, not enabled)
-  vim.notify("Inlay hints " .. (enabled and "disabled" or "enabled"))
-end, { desc = "Toggle Inlay Hints" })
--- <<< Inlay Hints
+local buffer_hint_state = {}
+
+local function supports_inlay_hints(client)
+  if not client then return false end
+  if type(client.supports_method) == "function" then
+    return client:supports_method "textDocument/inlayHint"
+  end
+  local capability = client.server_capabilities and client.server_capabilities.inlayHintProvider
+  return capability ~= nil and capability ~= false
+end
+
+local function set_inlay_hints(buf, enable)
+  if has_inlay_hint_enable then
+    vim.lsp.inlay_hint.enable(buf, enable)
+    return enable
+  elseif has_legacy_inlay_hint then
+    buffer_hint_state[buf] = enable and true or false
+    vim.lsp.buf.inlay_hint(buf, enable)
+    return buffer_hint_state[buf]
+  end
+end
+
+local function inlay_hints_is_enabled(buf)
+  if has_inlay_hint_is_enabled then
+    local ok, enabled = pcall(vim.lsp.inlay_hint.is_enabled, buf)
+    if ok then return enabled end
+  end
+  if has_legacy_inlay_hint then
+    return buffer_hint_state[buf] or false
+  end
+  return false
+end
+
+local function toggle_inlay_hints(buf)
+  local desired_state = not inlay_hints_is_enabled(buf)
+  local applied = set_inlay_hints(buf, desired_state)
+  if applied == nil then return desired_state end
+  return applied
+end
+
+if has_inlay_hint_enable or has_legacy_inlay_hint then
+  -- >>> Inlay Hints: по умолчанию выкл + тоггл по клавише
+  vim.api.nvim_create_autocmd("LspAttach", {
+    group = vim.api.nvim_create_augroup("UserInlayHints", { clear = true }),
+    callback = function(args)
+      if not args.data or not args.data.client_id then return end
+      local client = get_client_by_id(args.data.client_id)
+      if supports_inlay_hints(client) then
+        buffer_hint_state[args.buf] = false
+        set_inlay_hints(args.buf, false)
+      end
+    end,
+  })
+
+  -- Переключатель: <leader>uh (u = ui, h = hints)
+  vim.keymap.set("n", "<leader>uh", function()
+    local buf = vim.api.nvim_get_current_buf()
+    local enabled = toggle_inlay_hints(buf)
+    vim.notify("Inlay hints " .. (enabled and "enabled" or "disabled"))
+  end, { desc = "Toggle Inlay Hints" })
+  -- <<< Inlay Hints
+else
+  vim.keymap.set("n", "<leader>uh", function()
+    vim.notify("Inlay hints are not supported in this version of Neovim", vim.log.levels.WARN)
+  end, { desc = "Toggle Inlay Hints" })
+end
 
 local map = vim.keymap.set
 


### PR DESCRIPTION
## Summary
- add shared client-list helper so older and newer LSP APIs are supported without overriding globals
- harden inlay hint autocmd against missing attachment metadata
- reuse the compatibility helper when checking for gopls on save

## Testing
- not run (Neovim binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e181e0118083308e05bf7a49adb50c